### PR TITLE
Fix crash on "Unsupported module path: cmeel.prefix/lib/python3.12"

### DIFF
--- a/pydeps/private/index/index.py
+++ b/pydeps/private/index/index.py
@@ -76,7 +76,13 @@ def index(
         if _filter_dep_file(file):
             continue
 
-        mod = pm.PythonModule.from_path(pathlib.Path(file))
+        try:
+            mod = pm.PythonModule.from_path(pathlib.Path(file))
+        except ValueError as ve:
+            COLOR_PURPLE = "\033[35m"
+            COLOR_RESET = "\033[0m"
+            print(f"{COLOR_PURPLE}WARNING:{COLOR_RESET} {ve}")
+            continue
         req = _normalize_dep(dep)
 
         if mod in _IGNORE_MODULES:


### PR DESCRIPTION
This fixes #13 
See ticket for more info.

I'm not sure if this is the best solution.  Because it just prints the warning and continues instead of crashing.  But it works for my test cases.

If I add `pin` to the requirements file, then some errors are printed, but it doesn't crash:
```
baxelrod@baxelrod-ThinkPad:~/testcode/rules_pydeps/examples/demo$ bazel build thm/b
INFO: Analyzed target //thm/b:b (0 packages loaded, 0 targets configured).
INFO: From Action external/rules_pydeps~~reqs~reqs/pip_deps_index:
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
WARNING: Unsupported module path: cmeel.prefix/lib/python3.12
INFO: Found 1 target...
Aspect //:aspects.bzl%deps_enforcer of //thm/b:b up-to-date:
  bazel-bin/thm/b/b.deps
INFO: Elapsed time: 1.581s, Critical Path: 0.66s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
```

If I add a new dep to the `BUILD.bazel` file or source file (but not both), then I still get an appropriate failure.

```
baxelrod@baxelrod-ThinkPad:~/testcode/rules_pydeps/examples/demo$ bazel build thm/b
INFO: Analyzed target //thm/b:b (1 packages loaded, 2 targets configured).
ERROR: /home/baxelrod/testcode/rules_pydeps/examples/demo/thm/b/BUILD.bazel:4:11: CheckDeps thm/b/b.deps failed: (Exit 1): deps_cli failed: error executing CheckDeps command (from target //thm/b:b) bazel-out/k8-opt-exec-ST-d799b6585236/bin/external/rules_pydeps~/pydeps/private/enforcer/deps_cli aspect -g @@//thm/b:b -k py_library -i ... (remaining 9 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Bazel target @@//thm/b:b is missing requirements:
 - requirement("art")


Aspect //:aspects.bzl%deps_enforcer of //thm/b:b failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.596s, Critical Path: 0.44s
INFO: 2 processes: 2 internal.
ERROR: Build did NOT complete successfully
```